### PR TITLE
Corrected "yolo_body" to "yolo4_body" to match import.

### DIFF
--- a/yolo4.py
+++ b/yolo4.py
@@ -70,7 +70,7 @@ class YOLO(object):
             self.yolo_model = load_model(model_path, compile=False)
         except:
             self.yolo_model = tiny_yolo_body(Input(shape=(None,None,3)), num_anchors//2, num_classes) \
-                if is_tiny_version else yolo_body(Input(shape=(None,None,3)), num_anchors//3, num_classes)
+                if is_tiny_version else yolo4_body(Input(shape=(None,None,3)), num_anchors//3, num_classes)
             self.yolo_model.load_weights(self.model_path) # make sure model, anchors and classes match
         else:
             assert self.yolo_model.layers[-1].output_shape[-1] == \


### PR DESCRIPTION
Corrected "yolo_body" to "yolo4_body". This now matches the import on line 16:
`from yolo4.model import yolo_eval, yolo4_body`
"yolo_body" is a leftover from keras-yolo3.